### PR TITLE
Add Kubernetes manifests for video streaming stack

### DIFF
--- a/Docker/maifest/bff-deployment.yaml
+++ b/Docker/maifest/bff-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bff
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bff
+  template:
+    metadata:
+      labels:
+        app: bff
+    spec:
+      containers:
+        - name: bff
+          image: bff:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PORT
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bff
+spec:
+  selector:
+    app: bff
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/Docker/maifest/ffmpeg-deployment.yaml
+++ b/Docker/maifest/ffmpeg-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ffmpeg
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ffmpeg
+  template:
+    metadata:
+      labels:
+        app: ffmpeg
+    spec:
+      containers:
+        - name: ffmpeg
+          image: ffmpeg-service:latest
+          ports:
+            - containerPort: 8002
+          env:
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ffmpeg
+spec:
+  selector:
+    app: ffmpeg
+  ports:
+    - name: http
+      port: 8002
+      targetPort: 8002
+  type: ClusterIP

--- a/Docker/maifest/frontend-deployment.yaml
+++ b/Docker/maifest/frontend-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: frontend:latest
+          ports:
+            - containerPort: 8001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 8001
+      targetPort: 8001
+  type: ClusterIP

--- a/Docker/maifest/grafana-datasources-configmap.yaml
+++ b/Docker/maifest/grafana-datasources-configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+data:
+  datasources.yaml: |
+    apiVersion: 1
+
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+        editable: true
+
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki:3100
+        editable: true

--- a/Docker/maifest/grafana-deployment.yaml
+++ b/Docker/maifest/grafana-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "true"
+            - name: GF_SERVER_ROOT_URL
+              value: http://localhost/grafana
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: grafana-datasources
+              mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+              subPath: datasources.yaml
+            - name: grafana-storage
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources
+        - name: grafana-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/Docker/maifest/loki-configmap.yaml
+++ b/Docker/maifest/loki-configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+      chunk_idle_period: 5m
+      chunk_retain_period: 30s
+      max_chunk_age: 1h
+
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/index
+        cache_location: /loki/boltdb-cache
+      filesystem:
+        directory: /loki/chunks
+
+    limits_config:
+      retention_period: 168h # 7 days
+      allow_structured_metadata: false
+
+    table_manager:
+      retention_deletes_enabled: true
+      retention_period: 168h # 7 days
+
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 2048
+
+    common:
+      path_prefix: /tmp/loki

--- a/Docker/maifest/loki-deployment.yaml
+++ b/Docker/maifest/loki-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:latest
+          args:
+            - -config.file=/etc/loki/loki-config.yaml
+          ports:
+            - containerPort: 3100
+          volumeMounts:
+            - name: loki-config
+              mountPath: /etc/loki/loki-config.yaml
+              subPath: loki-config.yaml
+            - name: loki-storage
+              mountPath: /loki
+      volumes:
+        - name: loki-config
+          configMap:
+            name: loki-config
+        - name: loki-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+spec:
+  selector:
+    app: loki
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100
+  type: ClusterIP

--- a/Docker/maifest/minio-deployment.yaml
+++ b/Docker/maifest/minio-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /minio_data
+            - --console-address
+            - ":9001"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: MINIO_ROOT_USER
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: MINIO_ROOT_PASSWORD
+            - name: MINIO_ENDPOINT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: MINIO_ENDPOINT_URL
+            - name: MINIO_REGION_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: MINIO_REGION_NAME
+            - name: MINIO_BROWSER_REDIRECT_URL
+              value: http://localhost/minio/ui
+            - name: MINIO_PROMETHEUS_URL
+              value: http://prometheus:9090
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          volumeMounts:
+            - name: minio-data
+              mountPath: /minio_data
+      volumes:
+        - name: minio-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  type: ClusterIP

--- a/Docker/maifest/minio-secret.yaml
+++ b/Docker/maifest/minio-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+type: Opaque
+stringData:
+  MINIO_ROOT_USER: "123456789"
+  MINIO_ROOT_PASSWORD: "123456789"
+  MINIO_ENDPOINT_URL: "http://minio:9000"
+  MINIO_REGION_NAME: "eu-east-1"

--- a/Docker/maifest/nginx-configmap.yaml
+++ b/Docker/maifest/nginx-configmap.yaml
@@ -1,0 +1,183 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  nginx.conf: |
+    worker_processes auto;
+
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+        worker_connections 4096;
+    }
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        sendfile        on;
+        keepalive_timeout  65;
+
+        gzip on;
+        gzip_types text/plain application/javascript application/x-javascript text/css application/json;
+        gzip_comp_level 6;
+        gzip_min_length 1024;
+        gzip_proxied any;
+
+        upstream frontend_upstream {
+            server frontend:8001;
+#         server frontend2:8001;
+#         server frontend3:8001;
+        }
+
+        upstream bff_upstream {
+            server bff:8000;
+#         server bff2:8000;
+        }
+
+        server {
+            listen 80;
+            listen [::]:80;
+            server_name localhost;
+            http2 on;
+
+            add_header X-Frame-Options "SAMEORIGIN";
+            add_header X-Content-Type-Options "nosniff";
+            add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "strict-origin-when-cross-origin";
+
+            client_max_body_size 1000m;
+
+
+            location / {
+                proxy_pass http://frontend_upstream;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location /minio/videos/ {
+                proxy_buffering off;
+                proxy_pass_request_body off;
+                proxy_set_header Content-Length "";
+
+                # 1. Authorize and get the full signed URL from the backend
+                auth_request /signer;
+                auth_request_set $signed_url $upstream_http_x_signed_url;
+
+                # 2. Extract query string from signed URL
+                set $captured_query "";
+                if ($signed_url ~ \\?(.*)) {
+                    set $captured_query $1;
+                }
+
+                # 3. Proxy the original request to the full signed URL
+                proxy_pass $signed_url;
+
+                # 4. For manifest files, rewrite their content
+                # This finds lines that don't start with '#' and appends the signature
+                sub_filter_types application/vnd.apple.mpegurl;
+                sub_filter '.ts' '.ts?$captured_query';
+                sub_filter_once off;
+            }
+
+            location = /signer {
+                internal;
+                proxy_pass http://bff_upstream/api/video/sign_url?path=$request_uri;
+                proxy_pass_request_body off;
+                proxy_set_header Content-Length "";
+                proxy_set_header Host $host;
+            }
+
+            location ~ ^/api/(.*?)(/.*)?$ {
+                proxy_pass http://bff_upstream/api/$1$2$is_args$args;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location /docs {
+                proxy_pass http://bff_upstream/docs;
+            }
+
+            location /openapi.json {
+                proxy_pass http://bff_upstream/openapi.json;
+            }
+
+            location /minio/ {
+                proxy_set_header Host $proxy_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                proxy_connect_timeout 300;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+                chunked_transfer_encoding off;
+                proxy_pass http://minio:9000/;
+                proxy_buffering off;
+            }
+
+            location /minio/ui/ {
+                rewrite ^/minio/ui/(.*) /$1 break;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-NginX-Proxy true;
+
+                real_ip_header X-Real-IP;
+
+                proxy_connect_timeout 300;
+
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_redirect off;
+                chunked_transfer_encoding off;
+
+                proxy_pass http://minio:9001;
+
+            }
+
+            location ~* /rabbitmq/api/(.*?)/(.*) {
+                proxy_pass http://rabbitmq:15672/api/$1/%2F/$2?$query_string;
+            }
+
+            location ~* /rabbitmq/(.*) {
+                rewrite ^/rabbitmq/(.*)$ /$1 break;
+                proxy_pass http://rabbitmq:15672;
+            }
+
+            location /grafana/ {
+                proxy_pass http://grafana:3000;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+
+                proxy_redirect off;
+            }
+
+            location /prometheus/ {
+                proxy_pass http://prometheus:9090/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_redirect off;
+            }
+
+            location /rabbitmq {
+                rewrite ^/rabbitmq$ /rabbitmq/ permanent;
+            }
+        }
+    }

--- a/Docker/maifest/nginx-deployment.yaml
+++ b/Docker/maifest/nginx-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-gateway
+  template:
+    metadata:
+      labels:
+        app: nginx-gateway
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-gateway
+spec:
+  selector:
+    app: nginx-gateway
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      nodePort: 30080
+  type: NodePort

--- a/Docker/maifest/postgres-deployment.yaml
+++ b/Docker/maifest/postgres-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:latest
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /app/data/postgresql
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/Docker/maifest/postgres-pvc.yaml
+++ b/Docker/maifest/postgres-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/Docker/maifest/postgres-secret.yaml
+++ b/Docker/maifest/postgres-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+stringData:
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: test_db
+  POSTGRES_USER: test_user
+  POSTGRES_PASSWORD: test_pass

--- a/Docker/maifest/prometheus-configmap.yaml
+++ b/Docker/maifest/prometheus-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yaml: |
+    global:
+      scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+      evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+
+    scrape_configs:
+      - job_name: "fastapi"
+        metrics_path: /api/metrics
+        static_configs:
+          - targets: ["bff:8000"]
+
+      - job_name: "ffmpeg"
+        metrics_path: /api/metrics
+        static_configs:
+          - targets: ["ffmpeg:8002"]

--- a/Docker/maifest/prometheus-deployment.yaml
+++ b/Docker/maifest/prometheus-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args:
+            - --config.file=/etc/prometheus/prometheus.yaml
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus/prometheus.yaml
+              subPath: prometheus.yaml
+            - name: prometheus-data
+              mountPath: /prometheus
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+        - name: prometheus-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP

--- a/Docker/maifest/promtail-configmap.yaml
+++ b/Docker/maifest/promtail-configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+data:
+  promtail-config.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: docker-logs
+        static_configs:
+          - targets:
+              - localhost
+            labels:
+              job: docker-logs
+              __path__: /var/lib/docker/containers/*/*log
+
+        pipeline_stages:
+          - json:
+              expressions:
+                stream: stream
+                attrs: attrs
+                tag: attrs.tag
+
+          - regex:
+              expression: (?P<image_name>(?:[^|]*[^|])).(?P<container_name>(?:[^|]*[^|])).(?P<image_id>(?:[^|]*[^|])).(?P<container_id>(?:[^|]*[^|]))
+              source: "tag"
+
+          - labels:
+              tag:
+              image_name:
+              container_name:

--- a/Docker/maifest/promtail-deployment.yaml
+++ b/Docker/maifest/promtail-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promtail
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      containers:
+        - name: promtail
+          image: grafana/promtail:latest
+          args:
+            - -config.file=/etc/promtail/promtail-config.yaml
+          ports:
+            - containerPort: 9080
+          volumeMounts:
+            - name: docker-containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: docker-sock
+              mountPath: /var/run/docker.sock
+              readOnly: true
+            - name: promtail-config
+              mountPath: /etc/promtail/promtail-config.yaml
+              subPath: promtail-config.yaml
+      volumes:
+        - name: docker-containers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: promtail-config
+          configMap:
+            name: promtail-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: promtail
+spec:
+  selector:
+    app: promtail
+  ports:
+    - name: http
+      port: 9080
+      targetPort: 9080
+  type: ClusterIP

--- a/Docker/maifest/rabbitmq-deployment.yaml
+++ b/Docker/maifest/rabbitmq-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.8-management-alpine
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+    - name: management
+      port: 15672
+      targetPort: 15672
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add Kubernetes Deployments and Services mirroring the existing Docker Compose stack
- configure Secrets, ConfigMaps, and a PersistentVolumeClaim required for the database and supporting services