### PR TITLE
Add Kubernetes manifests for video streaming stack

### DIFF
--- a/Docker/manifest/README.md
+++ b/Docker/manifest/README.md
@@ -1,0 +1,35 @@
+# Kubernetes Manifests for Video Streaming Stack
+
+This directory contains Kubernetes resources that mirror the services defined in `Docker/docker-compose.yml`.
+
+## Contents
+
+- Namespace and shared service account for Vault agent injection.
+- ConfigMaps for nginx, Vault, and monitoring stack configurations.
+- A PersistentVolumeClaim dedicated to the PostgreSQL database.
+- Deployments and Services for every application component (backend, frontend, media processing, storage, messaging, monitoring, and Vault).
+
+## Vault integration
+
+All Deployments use the Vault Agent Injector to retrieve sensitive configuration. The following secrets (stored in Vault's KV store) are expected:
+
+| Service | Vault path | Expected keys |
+|---------|------------|---------------|
+| Backend API | `secret/data/backend/database` | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` |
+| Backend API | `secret/data/backend/s3` | `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `MINIO_ENDPOINT_URL`, `MINIO_REGION_NAME` |
+| PostgreSQL | `secret/data/postgres` | `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, optional connection overrides |
+| MinIO | `secret/data/minio` | `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `MINIO_ENDPOINT_URL`, etc. |
+| Grafana | `secret/data/grafana` | `GF_SECURITY_ADMIN_USER`, `GF_SECURITY_ADMIN_PASSWORD`, `GF_USERS_ALLOW_SIGN_UP`, `GF_SERVER_SERVE_FROM_SUB_PATH`, `GF_SERVER_ROOT_URL` |
+
+Ensure the Vault role `video-streaming` grants read access to these paths for the `vault-auth` service account.
+
+## Applying the manifests
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f configmap-gateway.yaml -f configmap-vault.yaml -f configmap-monitoring.yaml
+kubectl apply -f postgres-pvc.yaml
+kubectl apply -f deployment-*.yaml
+```
+
+Apply additional storage classes or adjust resource requests as required by your cluster.

--- a/Docker/manifest/configmap-gateway.yaml
+++ b/Docker/manifest/configmap-gateway.yaml
@@ -1,0 +1,206 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-gateway-config
+  namespace: video-streaming
+data:
+  nginx.conf: |
+    worker_processes auto;
+    
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+    
+    events {
+        worker_connections 4096;
+    }
+    
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+    
+        sendfile        on;
+        keepalive_timeout  65;
+    
+        gzip on;
+        gzip_types text/plain application/javascript application/x-javascript text/css application/json;
+        gzip_comp_level 6;
+        gzip_min_length 1024;
+        gzip_proxied any;
+    
+        upstream frontend_upstream {
+            server frontend:8001;
+    #         server frontend2:8001;
+    #         server frontend3:8001;
+        }
+    
+        upstream bff_upstream {
+            server bff:8000;
+    #         server bff2:8000;
+        }
+    
+        server {
+            listen 80;
+            listen [::]:80;
+            server_name localhost;
+            http2 on;
+    
+            add_header X-Frame-Options "SAMEORIGIN";
+            add_header X-Content-Type-Options "nosniff";
+            add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "strict-origin-when-cross-origin";
+    
+            client_max_body_size 1000m;
+    
+    
+            location / {
+                proxy_pass http://frontend_upstream;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+    
+            location /minio/videos/ {
+                proxy_buffering off;
+                proxy_pass_request_body off;
+                proxy_set_header Content-Length "";
+    
+                # 1. Authorize and get the full signed URL from the backend
+                auth_request /signer;
+                auth_request_set $signed_url $upstream_http_x_signed_url;
+    
+                # 2. Extract query string from signed URL
+                set $captured_query "";
+                if ($signed_url ~ \?(.*)) {
+                    set $captured_query $1;
+                }
+    
+                # 3. Proxy the original request to the full signed URL
+                proxy_pass $signed_url;
+    
+                # 4. For manifest files, rewrite their content
+                # This finds lines that don't start with '#' and appends the signature
+                sub_filter_types application/vnd.apple.mpegurl;
+                sub_filter '.ts' '.ts?$captured_query';
+                sub_filter_once off;
+            }
+    
+            location = /signer {
+                internal;
+                proxy_pass http://bff_upstream/api/video/sign_url?path=$request_uri;
+                proxy_pass_request_body off;
+                proxy_set_header Content-Length "";
+                proxy_set_header Host $host;
+            }
+    
+            location ~ ^/api/(.*?)(/.*)?$ {
+                proxy_pass http://bff_upstream/api/$1$2$is_args$args;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+    
+            location /docs {
+                proxy_pass http://bff_upstream/docs;
+            }
+    
+            location /openapi.json {
+                proxy_pass http://bff_upstream/openapi.json;
+            }
+    
+            location /minio/ {
+                proxy_set_header Host $proxy_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+    
+                proxy_connect_timeout 300;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+                chunked_transfer_encoding off;
+                proxy_pass http://minio:9000/;
+                proxy_buffering off;
+            }
+    
+            location /minio/ui/ {
+                rewrite ^/minio/ui/(.*) /$1 break;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-NginX-Proxy true;
+    
+                real_ip_header X-Real-IP;
+    
+                proxy_connect_timeout 300;
+    
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_redirect off;
+                chunked_transfer_encoding off;
+    
+                proxy_pass http://minio:9001;
+    
+            }
+    
+            location ~* /rabbitmq/api/(.*?)/(.*) {
+                proxy_pass http://rabbitmq:15672/api/$1/%2F/$2?$query_string;
+            }
+    
+            location ~* /rabbitmq/(.*) {
+                rewrite ^/rabbitmq/(.*)$ /$1 break;
+                proxy_pass http://rabbitmq:15672;
+            }
+    
+            location /grafana/ {
+                proxy_pass http://grafana:3000;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+    
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+    
+                proxy_redirect off;
+            }
+    
+            location /prometheus/ {
+                proxy_pass http://prometheus:9090/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_redirect off;
+            }
+    
+            location /rabbitmq {
+                rewrite ^/rabbitmq$ /rabbitmq/ permanent;
+            }
+    
+            location /ui/ {
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+    
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+                proxy_buffering off;
+    
+                proxy_pass http://vault:8200/ui/;
+            }
+    
+            location /v1/ {
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Host $server_name;
+    
+                proxy_pass "http://vault:8200/v1/";
+            }
+        }
+    }

--- a/Docker/manifest/configmap-monitoring.yaml
+++ b/Docker/manifest/configmap-monitoring.yaml
@@ -1,0 +1,139 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: video-streaming
+data:
+  promtail-config.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+    
+    positions:
+      filename: /tmp/positions.yaml
+    
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+    
+    scrape_configs:
+      - job_name: docker-logs
+        static_configs:
+          - targets:
+              - localhost
+            labels:
+              job: docker-logs
+              __path__: /var/lib/docker/containers/*/*log
+    
+        pipeline_stages:
+          - json:
+              expressions:
+                stream: stream
+                attrs: attrs
+                tag: attrs.tag
+    
+          - regex:
+              expression: (?P<image_name>(?:[^|]*[^|])).(?P<container_name>(?:[^|]*[^|])).(?P<image_id>(?:[^|]*[^|])).(?P<container_id>(?:[^|]*[^|]))
+              source: "tag"
+    
+          - labels:
+              tag:
+              image_name:
+              container_name:
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: video-streaming
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+    
+    server:
+      http_listen_port: 3100
+    
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+      chunk_idle_period: 5m
+      chunk_retain_period: 30s
+      max_chunk_age: 1h
+    
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/index
+        cache_location: /loki/boltdb-cache
+      filesystem:
+        directory: /loki/chunks
+    
+    limits_config:
+      retention_period: 168h # 7 days
+      allow_structured_metadata: false
+    
+    table_manager:
+      retention_deletes_enabled: true
+      retention_period: 168h # 7 days
+    
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 2048
+    
+    common:
+      path_prefix: /tmp/loki
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: video-streaming
+data:
+  prometheus.yaml: |
+    global:
+      scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+      evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+    
+    scrape_configs:
+      - job_name: "fastapi"
+        metrics_path: /api/metrics
+        static_configs:
+          - targets: ["bff:8000"]
+    
+      - job_name: "ffmpeg"
+        metrics_path: /api/metrics
+        static_configs:
+          - targets: ["ffmpeg:8002"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: video-streaming
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+        editable: true
+    
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki:3100
+        editable: true

--- a/Docker/manifest/configmap-vault.yaml
+++ b/Docker/manifest/configmap-vault.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-config
+  namespace: video-streaming
+data:
+  vault.hcl: |
+    listener "tcp" {
+      address                 = "0.0.0.0:8200"
+      # tls_cert_file = "/etc/vault/tls/vault.crt"
+      # tls_key_file  = "/etc/vault/tls/vault.key"
+      tls_disable             = 1
+      proxy_protocol_behavior = "use_always"
+    }
+    
+    
+    storage "raft" {
+      path    = "/opt/vault/data"
+      node_id = "vault-1"
+    }
+    
+    ui            = true
+    # max_lease_ttl     = "2160h"
+    # default_lease_ttl = "2160h"
+    log_level     = "INFO"
+    api_addr      = "http://vault:8200"
+    cluster_addr  = "http://vault:8201"
+    disable_mlock = true
+    
+    audit "file" {
+      path = "/var/log/vault_audit.log"
+    }

--- a/Docker/manifest/deployment-bff.yaml
+++ b/Docker/manifest/deployment-bff.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bff
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bff
+  template:
+    metadata:
+      labels:
+        app: bff
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "video-streaming"
+        vault.hashicorp.com/agent-inject-secret-database-env: "secret/data/backend/database"
+        vault.hashicorp.com/agent-inject-template-database-env: |
+          {{- with secret "secret/data/backend/database" -}}
+          {{- range $k, $v := .Data.data }}
+          {{ $k }}={{ $v }}
+          {{- end }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-file-database-env: "src/database.env"
+        vault.hashicorp.com/agent-inject-secret-s3-env: "secret/data/backend/s3"
+        vault.hashicorp.com/agent-inject-template-s3-env: |
+          {{- with secret "secret/data/backend/s3" -}}
+          {{- range $k, $v := .Data.data }}
+          {{ $k }}={{ $v }}
+          {{- end }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-file-s3-env: "src/s3.env"
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: bff
+          image: ghcr.io/video-streaming/bff:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bff
+  namespace: video-streaming
+spec:
+  selector:
+    app: bff
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/Docker/manifest/deployment-ffmpeg.yaml
+++ b/Docker/manifest/deployment-ffmpeg.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ffmpeg
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ffmpeg
+  template:
+    metadata:
+      labels:
+        app: ffmpeg
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: ffmpeg
+          image: ghcr.io/video-streaming/ffmpeg:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+          ports:
+            - containerPort: 8002
+              name: http
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ffmpeg
+  namespace: video-streaming
+spec:
+  selector:
+    app: ffmpeg
+  ports:
+    - name: http
+      port: 8002
+      targetPort: http

--- a/Docker/manifest/deployment-frontend.yaml
+++ b/Docker/manifest/deployment-frontend.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: frontend
+          image: ghcr.io/video-streaming/frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8001
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: video-streaming
+spec:
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 8001
+      targetPort: http

--- a/Docker/manifest/deployment-grafana.yaml
+++ b/Docker/manifest/deployment-grafana.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "video-streaming"
+        vault.hashicorp.com/agent-inject-secret-grafana-env: "secret/data/grafana"
+        vault.hashicorp.com/agent-inject-template-grafana-env: |
+          {{- with secret "secret/data/grafana" -}}
+          {{- range $k, $v := .Data.data }}
+          {{ $k }}={{ $v }}
+          {{- end }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-file-grafana-env: "grafana.env"
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - set -a; . /vault/secrets/grafana.env; exec /run.sh
+          ports:
+            - containerPort: 3000
+              name: http
+          volumeMounts:
+            - name: grafana-datasources
+              mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+              subPath: datasources.yaml
+            - name: grafana-data
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources
+        - name: grafana-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: video-streaming
+spec:
+  selector:
+    app: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/Docker/manifest/deployment-loki.yaml
+++ b/Docker/manifest/deployment-loki.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: loki
+          image: grafana/loki:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-config.file=/etc/loki/loki-config.yaml"]
+          ports:
+            - containerPort: 3100
+              name: http
+          volumeMounts:
+            - name: loki-config
+              mountPath: /etc/loki/loki-config.yaml
+              subPath: loki-config.yaml
+            - name: loki-data
+              mountPath: /loki
+      volumes:
+        - name: loki-config
+          configMap:
+            name: loki-config
+        - name: loki-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: video-streaming
+spec:
+  selector:
+    app: loki
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http

--- a/Docker/manifest/deployment-minio.yaml
+++ b/Docker/manifest/deployment-minio.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "video-streaming"
+        vault.hashicorp.com/agent-inject-secret-minio-env: "secret/data/minio"
+        vault.hashicorp.com/agent-inject-template-minio-env: |
+          {{- with secret "secret/data/minio" -}}
+          {{- range $k, $v := .Data.data }}
+          {{ $k }}={{ $v }}
+          {{- end }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-file-minio-env: "minio.env"
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - set -a; . /vault/secrets/minio.env; exec minio server /minio_data --console-address ":9001"
+          env:
+            - name: MINIO_BROWSER_REDIRECT_URL
+              value: http://localhost/minio/ui
+            - name: MINIO_PROMETHEUS_URL
+              value: http://prometheus:9090
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          volumeMounts:
+            - name: data
+              mountPath: /minio_data
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 20
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: video-streaming
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: api
+    - name: console
+      port: 9001
+      targetPort: console

--- a/Docker/manifest/deployment-nginx.yaml
+++ b/Docker/manifest/deployment-nginx.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: nginx-gateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: video-streaming
+spec:
+  selector:
+    app: nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: LoadBalancer

--- a/Docker/manifest/deployment-postgres.yaml
+++ b/Docker/manifest/deployment-postgres.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "video-streaming"
+        vault.hashicorp.com/agent-inject-secret-postgres-env: "secret/data/postgres"
+        vault.hashicorp.com/agent-inject-template-postgres-env: |
+          {{- with secret "secret/data/postgres" -}}
+          {{- range $k, $v := .Data.data }}
+          {{ $k }}={{ $v }}
+          {{- end }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-file-postgres-env: "postgres.env"
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: postgres
+          image: postgres:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          command: ["/bin/sh", "-c"]
+          args:
+            - set -a; . /vault/secrets/postgres.env; exec docker-entrypoint.sh postgres
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 5
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: video-streaming
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres

--- a/Docker/manifest/deployment-prometheus.yaml
+++ b/Docker/manifest/deployment-prometheus.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yaml"
+            - "--storage.tsdb.path=/prometheus"
+          ports:
+            - containerPort: 9090
+              name: http
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus/prometheus.yaml
+              subPath: prometheus.yaml
+            - name: prometheus-data
+              mountPath: /prometheus
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+        - name: prometheus-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: video-streaming
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http

--- a/Docker/manifest/deployment-promtail.yaml
+++ b/Docker/manifest/deployment-promtail.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promtail
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: promtail
+          image: grafana/promtail:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-config.file=/etc/promtail/promtail-config.yaml"]
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9080
+              name: http
+          volumeMounts:
+            - name: promtail-config
+              mountPath: /etc/promtail/promtail-config.yaml
+              subPath: promtail-config.yaml
+            - name: docker-containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+      volumes:
+        - name: promtail-config
+          configMap:
+            name: promtail-config
+        - name: docker-containers
+          hostPath:
+            path: /var/lib/docker/containers
+            type: Directory
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: promtail
+  namespace: video-streaming
+spec:
+  selector:
+    app: promtail
+  ports:
+    - name: http
+      port: 9080
+      targetPort: http

--- a/Docker/manifest/deployment-rabbitmq.yaml
+++ b/Docker/manifest/deployment-rabbitmq.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.8-management-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5672
+              name: amqp
+            - containerPort: 15672
+              name: management
+          readinessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "status"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          livenessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "status"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: video-streaming
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: amqp
+    - name: management
+      port: 15672
+      targetPort: management

--- a/Docker/manifest/deployment-vault.yaml
+++ b/Docker/manifest/deployment-vault.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault
+  namespace: video-streaming
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vault
+  template:
+    metadata:
+      labels:
+        app: vault
+    spec:
+      serviceAccountName: vault-auth
+      containers:
+        - name: vault
+          image: hashicorp/vault:latest
+          imagePullPolicy: IfNotPresent
+          command: ["vault", "server", "-config=/etc/vault/vault.hcl"]
+          env:
+            - name: VAULT_ADDR
+              value: http://vault:8200
+            - name: VAULT_API_ADDR
+              value: http://vault:8200
+            - name: VAULT_CLUSTER_ADDR
+              value: http://vault:8201
+          ports:
+            - containerPort: 8200
+              name: http
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+          volumeMounts:
+            - name: vault-config
+              mountPath: /etc/vault/vault.hcl
+              subPath: vault.hcl
+            - name: vault-data
+              mountPath: /opt/vault/data
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "vault status -address=http://127.0.0.1:8200"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "vault status -address=http://127.0.0.1:8200"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+      volumes:
+        - name: vault-config
+          configMap:
+            name: vault-config
+        - name: vault-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: video-streaming
+spec:
+  selector:
+    app: vault
+  ports:
+    - name: http
+      port: 8200
+      targetPort: http

--- a/Docker/manifest/namespace.yaml
+++ b/Docker/manifest/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: video-streaming
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: video-streaming

--- a/Docker/manifest/postgres-pvc.yaml
+++ b/Docker/manifest/postgres-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: video-streaming
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
## Summary
- introduce Kubernetes manifests that mirror the existing Docker Compose services
- configure Vault agent injection for all secrets and database credentials
- provide ConfigMaps, Services, and a PostgreSQL PVC required for the stack