### PR TITLE
Refine backend dependencies and API documentation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
 def create_app(use_lifespan: bool = True) -> FastAPI:
     lifespan_ctx = lifespan if use_lifespan else None
     app = FastAPI(
-        title="My API", description="BFF", version="1.0.0", lifespan=lifespan_ctx
+        title="Video Streaming BFF",
+        description="Backend service powering the video streaming experience.",
+        version="1.0.0",
+        docs_url="/api/docs",
+        redoc_url=None,
+        openapi_url="/api/openapi.json",
+        swagger_ui_parameters={
+            "defaultModelsExpandDepth": -1,
+            "displayRequestDuration": True,
+            "docExpansion": "none",
+            "supportedSubmitMethods": [],
+        },
+        lifespan=lifespan_ctx,
     )
 
     app.include_router(router_health)

--- a/backend/src/api/files.py
+++ b/backend/src/api/files.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 import uuid
 from datetime import datetime
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import Response, StreamingResponse
@@ -12,13 +14,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.pagination import paginate_query
 from ..infrastructure import get_s3_client
 from ..infrastructure.database import get_async_session
-from ..infrastructure.rabbit_client import rabbit_broker
+from ..infrastructure.rabbit_client import get_rabbit_broker
 from ..models import Video
 from ..models.comments import Comment
 from ..schemas.comments import CommentPage
 from ..schemas.endpoint import ErrorResponse, FileMeta, UploadResponse
 from ..schemas.enum import Privacy
 from ..schemas.video import VideoPage, VideoPlayback
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
+    from faststream.rabbit import RabbitBroker
+
+    from ..infrastructure.s3_client import S3Client
 
 router_files = APIRouter(prefix="/api/video", tags=["files"])
 
@@ -31,6 +38,8 @@ router_files = APIRouter(prefix="/api/video", tags=["files"])
 )
 async def upload_files(
     uploaded_files: List[UploadFile],
+    s3_client: S3Client = Depends(get_s3_client),
+    broker: RabbitBroker = Depends(get_rabbit_broker),
 ) -> UploadResponse:
     """
     Upload multiple files to S3 asynchronously and trigger encoding tasks in RabbitMQ.
@@ -41,7 +50,6 @@ async def upload_files(
         raise HTTPException(status_code=400, detail="No files provided")
 
     files_meta: List[FileMeta] = []
-    s3_client = get_s3_client()
     semaphore = asyncio.Semaphore(5)
 
     async def upload_single_file(uploaded_file: UploadFile) -> None:
@@ -63,7 +71,7 @@ async def upload_files(
             await s3_client.upload_file(
                 new_filename, uploaded_file.file, bucket_name="videos"
             )
-            await rabbit_broker.publish(new_filename, queue="video.encode")
+            await broker.publish(new_filename, queue="video.encode")
 
     try:
         tasks = [upload_single_file(f) for f in uploaded_files]
@@ -78,8 +86,9 @@ async def upload_files(
 
 
 @router_files.get("/download/{filename:path}")
-async def get_file(filename: str) -> StreamingResponse:
-    s3_client = get_s3_client()
+async def get_file(
+    filename: str, s3_client: S3Client = Depends(get_s3_client)
+) -> StreamingResponse:
     try:
         logging.info(f"Downloading file: {filename}")
         chunk_generator = s3_client.download_file(
@@ -98,8 +107,9 @@ async def get_file(filename: str) -> StreamingResponse:
 
 
 @router_files.get("/sign_url")
-async def sign_object(path: str) -> Response:
-    s3_client = get_s3_client()
+async def sign_object(
+    path: str, s3_client: S3Client = Depends(get_s3_client)
+) -> Response:
     path = path.replace("/minio/videos/", "")
     try:
         raw_presigned_url = await s3_client.generate_presigned_url(

--- a/backend/src/api/metrics.py
+++ b/backend/src/api/metrics.py
@@ -28,9 +28,8 @@ EXCLUDE_PATH_PREFIXES: List[str] = [
     "/api/metrics",
     "/api/health",
     "/static",
-    "/docs",
-    "/openapi.json",
-    "/redoc",
+    "/api/docs",
+    "/api/openapi.json",
 ]
 
 

--- a/backend/src/infrastructure/__init__.py
+++ b/backend/src/infrastructure/__init__.py
@@ -1,5 +1,12 @@
 from .database import Base, get_async_session
-from .rabbit_client import rabbit_broker
+from .rabbit_client import get_rabbit_broker, rabbit_broker
 from .s3_client import S3Client, get_s3_client
 
-__all__ = ["S3Client", "Base", "get_async_session", "get_s3_client", "rabbit_broker"]
+__all__ = [
+    "S3Client",
+    "Base",
+    "get_async_session",
+    "get_s3_client",
+    "rabbit_broker",
+    "get_rabbit_broker",
+]

--- a/backend/src/infrastructure/rabbit_client.py
+++ b/backend/src/infrastructure/rabbit_client.py
@@ -7,6 +7,12 @@ from ..schemas.endpoint import StatusMessage
 rabbit_broker = RabbitBroker(url="amqp://guest:guest@rabbitmq:5672/")
 
 
+def get_rabbit_broker() -> RabbitBroker:
+    """Provide the shared RabbitMQ broker instance for dependency injection."""
+
+    return rabbit_broker
+
+
 @rabbit_broker.subscriber("video.encode.status")
 async def status_handler(msg: StatusMessage) -> None:
     logging.info(f"Video {msg.video_id} is {msg.status}")


### PR DESCRIPTION
## Summary
- inject the S3 client and RabbitMQ broker through FastAPI dependency injection while keeping heavy imports type-only
- expose a helper to retrieve the shared RabbitMQ broker and update infrastructure exports
- rebrand the FastAPI application metadata and harden the Swagger UI configuration for production, updating metrics exclusions accordingly