### PR TITLE
Document metrics endpoint response

### DIFF
--- a/backend/src/api/metrics.py
+++ b/backend/src/api/metrics.py
@@ -24,7 +24,30 @@ router_metrics = APIRouter(
 )
 
 
-@router_metrics.get("", include_in_schema=True)
+@router_metrics.get(
+    "",
+    include_in_schema=True,
+    summary="Retrieve Prometheus metrics",
+    description=(
+        "Expose the application's Prometheus-formatted metrics for scraping by "
+        "monitoring systems."
+    ),
+    response_description="Plain text payload containing Prometheus metrics.",
+    responses={
+        200: {
+            "description": "Successful metrics response",
+            "content": {
+                "text/plain; version=0.0.4": {
+                    "schema": {
+                        "type": "string",
+                        "example": "# HELP http_requests_total Total HTTP requests\n# TYPE http_requests_total counter",
+                    }
+                }
+            },
+        }
+    },
+    response_class=Response,
+)
 async def get_metrics_doc() -> Response:
     """
     Prometheus metrics endpoint


### PR DESCRIPTION
## Summary
- document the Prometheus metrics route with a summary, description, and explicit response metadata
- declare the plain text response class and content type so OpenAPI accurately represents the metrics payload
